### PR TITLE
fix: specified fetch-depth

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,6 +10,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 全履歴を取得
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
readmeはちゃんと読みましょう。
- https://github.com/gitleaks/gitleaks-action/tree/master?tab=readme-ov-file#usage-example

指定してなかったせいでgitのコミット履歴を取得しきれずactionがこけてた。
- https://github.com/guricerin/homebound/actions/runs/13614194279